### PR TITLE
Update epoll to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "bluebird": "^3.3.4",
-    "epoll": "^0.1.17"
+    "epoll": "^2.0.1"
   }
 }


### PR DESCRIPTION
The package didn't install because epoll wouldn't build, updating to the latest version fixed the problem.